### PR TITLE
Replace deprecated django.conf.urls.url with django.urls.re_path #4

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -2,9 +2,9 @@ name: Run Tests
 
 on:
   push:
-    branches: [ "main", "scenario/*", "eval/*", "feature/*" ]
+    branches: [ "master", "main", "scenario/*", "eval/*", "feature/*" ]
   pull_request:
-    branches: [ "main", "scenario/*", "eval/*", "feature/*" ]
+    branches: [ "master", "main", "scenario/*", "eval/*", "feature/*" ]
 
 jobs:
   build:

--- a/conduit/apps/articles/urls.py
+++ b/conduit/apps/articles/urls.py
@@ -1,5 +1,4 @@
-from django.conf.urls import include, url
-
+from django.urls import include, re_path
 from rest_framework.routers import DefaultRouter
 
 from .views import (
@@ -11,18 +10,18 @@ router = DefaultRouter(trailing_slash=False)
 router.register(r'articles', ArticleViewSet)
 
 urlpatterns = [
-    url(r'^', include(router.urls)),
+    re_path(r'^', include(router.urls)),
 
-    url(r'^articles/feed/?$', ArticlesFeedAPIView.as_view()),
+    re_path(r'^articles/feed/?$', ArticlesFeedAPIView.as_view()),
 
-    url(r'^articles/(?P<article_slug>[-\w]+)/favorite/?$',
+    re_path(r'^articles/(?P<article_slug>[-\w]+)/favorite/?$',
         ArticlesFavoriteAPIView.as_view()),
 
-    url(r'^articles/(?P<article_slug>[-\w]+)/comments/?$', 
+    re_path(r'^articles/(?P<article_slug>[-\w]+)/comments/?$',
         CommentsListCreateAPIView.as_view()),
 
-    url(r'^articles/(?P<article_slug>[-\w]+)/comments/(?P<comment_pk>[\d]+)/?$',
+    re_path(r'^articles/(?P<article_slug>[-\w]+)/comments/(?P<comment_pk>[\d]+)/?$',
         CommentsDestroyAPIView.as_view()),
 
-    url(r'^tags/?$', TagListAPIView.as_view()),
+    re_path(r'^tags/?$', TagListAPIView.as_view()),
 ]

--- a/conduit/apps/authentication/urls.py
+++ b/conduit/apps/authentication/urls.py
@@ -1,11 +1,11 @@
-from django.conf.urls import url
+from django.urls import re_path
 
 from .views import (
     LoginAPIView, RegistrationAPIView, UserRetrieveUpdateAPIView
 )
 
 urlpatterns = [
-    url(r'^user/?$', UserRetrieveUpdateAPIView.as_view()),
-    url(r'^users/?$', RegistrationAPIView.as_view()),
-    url(r'^users/login/?$', LoginAPIView.as_view()),
+    re_path(r'^user/?$', UserRetrieveUpdateAPIView.as_view()),
+    re_path(r'^users/?$', RegistrationAPIView.as_view()),
+    re_path(r'^users/login/?$', LoginAPIView.as_view()),
 ]

--- a/conduit/apps/core/tests.py
+++ b/conduit/apps/core/tests.py
@@ -1,0 +1,80 @@
+from django.test import TestCase
+from django.core.management import call_command
+from django.core.management.base import SystemCheckError
+from io import StringIO
+
+from django.urls import URLPattern, URLResolver
+
+from conduit import settings
+
+
+def list_urls(lis, acc=None):
+    if acc is None:
+        acc = []
+    if not lis:
+        return
+    l = lis[0]
+    if isinstance(l, URLPattern):
+        yield acc + [str(l.pattern)]
+    elif isinstance(l, URLResolver):
+        yield from list_urls(l.url_patterns, acc + [str(l.pattern)])
+    yield from list_urls(lis[1:], acc)
+
+
+class SystemHealthTests(TestCase):
+    def test_system_check_errors(self):
+        """
+        Test that the system has no errors during startup checks.
+        Particularly checking CORS configuration and other critical settings.
+        """
+        stdout = StringIO()
+        stderr = StringIO()
+        try:
+            # Run system checks
+            call_command('check', stdout=stdout, stderr=stderr)
+        except SystemCheckError:
+            self.fail(
+                f"System checks failed!\nOutput: {stdout.getvalue()}\nErrors: {stderr.getvalue()}"
+            )
+
+    def test_all_urls(self):
+        urlconf = __import__(settings.ROOT_URLCONF, {}, {}, [''])
+        actual_urls = [''.join(p) for p in list_urls(urlconf.urlpatterns)]
+
+        expected_urls = [
+            '^admin/',
+            '^admin/login/',
+            '^admin/logout/',
+            '^admin/password_change/',
+            '^admin/password_change/done/',
+            '^admin/autocomplete/',
+            '^admin/jsi18n/',
+            '^admin/r/<path:content_type_id>/<path:object_id>/',
+            '^admin/auth/group/',
+            '^admin/auth/group/add/',
+            '^admin/auth/group/<path:object_id>/history/',
+            '^admin/auth/group/<path:object_id>/delete/',
+            '^admin/auth/group/<path:object_id>/change/',
+            '^admin/auth/group/<path:object_id>/',
+            '^admin/^(?P<app_label>auth)/$',
+            '^admin/(?P<url>.*)$',
+            '^api/^^articles$',
+            '^api/^^articles\\.(?P<format>[a-z0-9]+)/?$',
+            '^api/^^articles/(?P<slug>[^/.]+)$',
+            '^api/^^articles/(?P<slug>[^/.]+)\\.(?P<format>[a-z0-9]+)/?$',
+            '^api/^',
+            '^api/^<drf_format_suffix:format>',
+            '^api/^articles/feed/?$',
+            '^api/^articles/(?P<article_slug>[-\\w]+)/favorite/?$',
+            '^api/^articles/(?P<article_slug>[-\\w]+)/comments/?$',
+            '^api/^articles/(?P<article_slug>[-\\w]+)/comments/(?P<comment_pk>[\\d]+)/?$',
+            '^api/^tags/?$',
+            '^api/^user/?$',
+            '^api/^users/?$',
+            '^api/^users/login/?$',
+            '^api/^profiles/(?P<username>\\w+)/?$',
+            '^api/^profiles/(?P<username>\\w+)/follow/?$',
+        ]
+
+        # Optional: sort both lists for easier comparison
+        self.assertEqual(sorted(actual_urls), sorted(expected_urls))

--- a/conduit/apps/profiles/urls.py
+++ b/conduit/apps/profiles/urls.py
@@ -1,9 +1,9 @@
-from django.conf.urls import url
+from django.urls import re_path
 
 from .views import ProfileRetrieveAPIView, ProfileFollowAPIView
 
 urlpatterns = [
-    url(r'^profiles/(?P<username>\w+)/?$', ProfileRetrieveAPIView.as_view()),
-    url(r'^profiles/(?P<username>\w+)/follow/?$', 
+    re_path(r'^profiles/(?P<username>\w+)/?$', ProfileRetrieveAPIView.as_view()),
+    re_path(r'^profiles/(?P<username>\w+)/follow/?$',
         ProfileFollowAPIView.as_view()),
 ]

--- a/conduit/urls.py
+++ b/conduit/urls.py
@@ -13,13 +13,13 @@ Including another URLconf
     1. Import the include() function: from django.conf.urls import url, include
     2. Add a URL to urlpatterns:  url(r'^blog/', include('blog.urls'))
 """
-from django.conf.urls import include, url
 from django.contrib import admin
+from django.urls import include, re_path
 
 urlpatterns = [
-    url(r'^admin/', admin.site.urls),
+    re_path(r'^admin/', admin.site.urls),
 
-    url(r'^api/', include('conduit.apps.articles.urls', namespace='articles')),
-    url(r'^api/', include('conduit.apps.authentication.urls', namespace='authentication')),
-    url(r'^api/', include('conduit.apps.profiles.urls', namespace='profiles')),
+    re_path(r'^api/', include(('conduit.apps.articles.urls', 'articles'), namespace='articles')),
+    re_path(r'^api/', include(('conduit.apps.authentication.urls', 'authentication'), namespace='authentication')),
+    re_path(r'^api/', include(('conduit.apps.profiles.urls', 'profiles'), namespace='profiles')),
 ]


### PR DESCRIPTION
After upgrading Django from 1.10.5 to 5.2.4 there is an exception:
```
from django.conf.urls import include, url
ImportError: cannot import name 'url' from 'django.conf.urls'. Did you mean: 'urls'?
```
All deprecated `url` calls must be replaced with `re_path` ensuring there are no more exceptions.